### PR TITLE
ci: add regenerate-api-types workflow

### DIFF
--- a/.github/workflows/regenerate-api-types.yml
+++ b/.github/workflows/regenerate-api-types.yml
@@ -1,0 +1,85 @@
+name: Regenerate API Types
+
+on:
+  repository_dispatch:
+    types: [api-types-updated]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  regenerate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout firela-app
+        uses: actions/checkout@v4
+
+      # Java required by openapi_generator (JAR-based tool)
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@v1
+        with:
+          sdk: '3.2.0'
+
+      - name: Cache pub packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.pub-cache
+          key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pub-
+
+      - name: Install dependencies
+        run: dart pub get
+
+      # Download spec from firela-app's own main branch (where spec-publish-sync.yml pushed it)
+      - name: Download latest spec
+        run: |
+          curl -sL -o openapi.yaml \
+            https://raw.githubusercontent.com/fire-la/firela-app/main/lib/api/spec/openapi.yaml
+
+      # Update build.yaml to eliminate deprecated api-specs fallback URL
+      - name: Update build.yaml URL
+        run: |
+          sed -i 's|https://raw.githubusercontent.com/fire-la/api-specs/main/openapi.yaml|https://raw.githubusercontent.com/fire-la/firela-app/main/lib/api/spec/openapi.yaml|g' build.yaml
+
+      - name: Generate types
+        run: dart run build_runner build --delete-conflicting-outputs
+
+      - name: Verify compilation
+        run: dart analyze lib/api/generated/
+
+      - name: Create PR if changed
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: sync/api-types
+          title: "chore: regenerate Dart API types from OpenAPI spec"
+          commit-message: "chore: regenerate Dart API types from OpenAPI spec + update build.yaml URL"
+          labels: automated, api-types
+          body: |
+            Auto-regenerated Dart API types from OpenAPI spec.
+
+            **Trigger:** ign@${{ github.event.client_payload.sha }}
+
+      - name: Report failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.create({
+              owner: 'fire-la',
+              repo: 'firela-app',
+              title: `API type regeneration failed: ${context.sha}`,
+              body: `Regeneration triggered by ign@${{ github.event.client_payload.sha }}.\n\n[View run](${context.serverUrl}/${context.repository.full_name}/actions/runs/${context.runId})`,
+              labels: ['api-types-failure']
+            })

--- a/lib/api/TYPE_GENERATION_GUIDE.md
+++ b/lib/api/TYPE_GENERATION_GUIDE.md
@@ -116,7 +116,7 @@ final response = await transactionApi.createTransaction(
 
 ```bash
 # Run with local backend
-flutter run --dart-define=API_URL=http://localhost:3333/api/v1
+flutter run --dart-define=API_URL=http://localhost:3334/api/v1
 ```
 
 ### Production

--- a/lib/api/TYPE_GENERATION_GUIDE.md
+++ b/lib/api/TYPE_GENERATION_GUIDE.md
@@ -1,221 +1,68 @@
-# Flutter API Types Integration Guide
+# Flutter API Integration Guide
 
 ## Overview
 
-This document explains how to use type-safe API calls in the firela Flutter app using generated types from the OpenAPI specification.
+The firela Flutter app uses **manual Dio HTTP wrappers** to communicate with the IGN backend API. API types are defined manually in Dart.
 
-## Architecture
+## Current Architecture
 
 ```
-┌─────────────────────────────────────────┐
-│   OpenAPI Spec (fire-la/api-specs)      │
-│   - Single source of truth              │
-│   - TypeScript types (npm)              │
-│   - Dart types (generated locally)      │
-└─────────────────────────────────────────┘
-                  │
-                  ▼
 ┌─────────────────────────────────────────┐
 │   firela Flutter App                    │
-│   - openapi_generator (Dart package)    │
-│   - build_runner (code generation)      │
-│   - lib/api/generated/ (output)         │
+│                                         │
+│   api/api_client.dart  — Dio HTTP client │
+│   api/ign_api.dart     — API services   │
+│   api/region_types.dart — Region types  │
+│                                         │
+│   (No generated types currently)        │
+└─────────────────────────────────────────┘
+         │
+         ▼
+┌─────────────────────────────────────────┐
+│   IGN Backend (NestJS)                  │
+│   OpenAPI spec: libs/api-types/openapi.yaml │
+│   npm package: @firela/api-types         │
 └─────────────────────────────────────────┘
 ```
 
-## Setup (One-time)
+## API Files
 
-### 1. Install Flutter SDK
-
-```bash
-# Download Flutter SDK
-# See: https://docs.flutter.dev/get-started/install
-
-# Verify installation
-flutter doctor
-```
-
-### 2. Install Dependencies
-
-```bash
-cd /Users/xiafang/Documents/firela
-flutter pub get
-```
-
-### 3. Generate API Types
-
-```bash
-# Run code generator
-flutter pub run build_runner build --delete-conflicting-outputs
-
-# Or watch mode (regenerate on changes)
-flutter pub run build_runner watch --delete-conflicting-outputs
-```
-
-### 4. Verify Generation
-
-```bash
-ls lib/api/generated/
-# Should see generated Dart files
-```
-
-## Usage
-
-### API Client
-
-```dart
-import 'package:firela/api/api_client.dart';
-
-final client = ApiClient();
-
-// Set auth token after login
-client.setAuthToken('your-jwt-token');
-
-// Clear on logout
-client.clearAuthToken();
-```
-
-### API Service
-
-```dart
-import 'package:firela/api/api_service_example.dart';
-
-final healthService = HealthService();
-final status = await healthService.checkHealth();
-
-final transactionService = TransactionService();
-final transactions = await transactionService.listTransactions('de');
-```
-
-### Generated Types (after running build_runner)
-
-```dart
-import 'package:firela/api/generated/openapi.dart';
-
-// Use generated types for type safety
-final request = CreateTransactionRequest(
-  date: '2024-01-15',
-  payee: 'Coffee Shop',
-  postings: [
-    Posting(
-      account: 'Expenses:Coffee',
-      amount: Amount(number: 5.0, currency: 'EUR'),
-    ),
-  ],
-);
-
-final response = await transactionApi.createTransaction(
-  region: 'de',
-  request: request,
-);
-```
+| File | Purpose |
+|------|---------|
+| `api_client.dart` | Dio HTTP client singleton with env-based URL config |
+| `ign_api.dart` | Manual API service classes (Account, Transaction, etc.) |
+| `region_types.dart` | RegionConfig and related data types |
 
 ## Environment Configuration
 
 ### Development
 
 ```bash
-# Run with local backend
 flutter run --dart-define=API_URL=http://localhost:3334/api/v1
 ```
 
 ### Production
 
 ```bash
-# Run with production API
 flutter run --dart-define=API_URL=https://api.firela.com/api/v1
 ```
 
-## Updating Types
+## Adding New API Endpoints
 
-When the OpenAPI spec changes:
+1. Add the route to the IGN backend OpenAPI spec (`libs/api-types/openapi.yaml`)
+2. Rebuild `@firela/api-types` npm package (`npm run build` in `libs/api-types/`)
+3. Manually add the corresponding Dart method in `ign_api.dart`
+4. Define any new Dart types in `region_types.dart` or create a new types file
 
-```bash
-# 1. Pull latest spec from api-specs repo
-# (Spec is fetched from GitHub URL in build.yaml)
+## Planned: OpenAPI Code Generation
 
-# 2. Regenerate types
-flutter pub run build_runner build --delete-conflicting-outputs
+The following are configured but **not yet in use**:
 
-# 3. Fix any breaking changes in your code
-# The generator will catch type errors at compile time
-```
+- `pubspec.yaml`: `openapi_generator` and `openapi_generator_annotations` dependencies
+- `build.yaml`: Configured for `dart-dio` generator with output to `lib/api/generated/`
 
-## Alternative: Using Local Spec
+When ready to enable code generation:
 
-To use a local OpenAPI spec file instead of GitHub URL:
-
-1. Download spec:
-   ```bash
-   curl -o openapi.yaml https://raw.githubusercontent.com/fire-la/api-specs/main/openapi.yaml
-   ```
-
-2. Update `build.yaml`:
-   ```yaml
-   input_spec:
-     path: openapi.yaml  # Use local file
-     # url: ...  # Comment out URL
-   ```
-
-## Troubleshooting
-
-### Generation Fails
-
-```bash
-# Clean and rebuild
-flutter clean
-flutter pub get
-flutter pub run build_runner clean
-flutter pub run build_runner build --delete-conflicting-outputs
-```
-
-### Type Errors
-
-1. Check that OpenAPI spec is valid
-2. Run `spectral lint openapi.yaml` in api-specs repo
-3. Regenerate types
-
-### Network Errors
-
-1. Check `API_URL` environment variable
-2. Verify backend is running
-3. Check network connectivity
-
-## CI/CD Integration
-
-Add to your CI pipeline:
-
-```yaml
-- name: Generate API Types
-  run: flutter pub run build_runner build --delete-conflicting-outputs
-
-- name: Check for Generated Files
-  run: test -d lib/api/generated
-```
-
-## Best Practices
-
-1. **Always commit generated code** (not in .gitignore)
-2. **Regenerate on API changes** - Keep types in sync
-3. **Use generated types everywhere** - Don't manually define API types
-4. **Handle errors with try/catch** - DioException for network errors
-5. **Add authentication interceptor** - Centralize auth token handling
-
-## Related Files
-
-- `pubspec.yaml` - Dependencies configuration
-- `build.yaml` - OpenAPI generator configuration
-- `lib/api/api_client.dart` - HTTP client setup
-- `lib/api/api_service_example.dart` - Usage examples
-- `lib/api/generated/` - Generated types (after running build_runner)
-
-## Next Steps
-
-1. Install Flutter SDK
-2. Run `flutter pub get`
-3. Run `flutter pub run build_runner build`
-4. Use generated types in your widgets
-
-For questions, see:
-- [OpenAPI Generator for Dart](https://github.com/gibahjoe/openapi-generator-dart)
-- [Flutter HTTP & APIs](https://docs.flutter.dev/data-and-backend/networking)
+1. Run `flutter pub run build_runner build --delete-conflicting-outputs`
+2. Generated types will appear in `lib/api/generated/`
+3. Replace manual wrappers with generated types

--- a/lib/api/api_client.dart
+++ b/lib/api/api_client.dart
@@ -19,7 +19,7 @@ class ApiClient {
     _dio = Dio(BaseOptions(
       baseUrl: const String.fromEnvironment(
         'API_URL',
-        defaultValue: 'http://localhost:3333/api/v1',
+        defaultValue: 'http://localhost:3334/api/v1',
       ),
       connectTimeout: const Duration(seconds: 30),
       receiveTimeout: const Duration(seconds: 30),

--- a/lib/api/region_types.dart
+++ b/lib/api/region_types.dart
@@ -29,25 +29,17 @@ class Region {
 }
 
 /// Region configuration
+///
+/// Mirrors the backend's RegionConfigDto (currency, dateFormat, locale).
 class RegionConfig {
   final String currency;
   final String dateFormat;
   final String locale;
-  final String? decimalSeparator;
-  final String? thousandsSeparator;
-  final String? currencySymbol;
-  final String? currencyPosition;
-  final List<String>? sharedFeatures;
 
   const RegionConfig({
     required this.currency,
     required this.dateFormat,
     required this.locale,
-    this.decimalSeparator,
-    this.thousandsSeparator,
-    this.currencySymbol,
-    this.currencyPosition,
-    this.sharedFeatures,
   });
 
   factory RegionConfig.fromJson(Map<String, dynamic> json) {
@@ -55,13 +47,6 @@ class RegionConfig {
       currency: json['currency'] as String,
       dateFormat: json['dateFormat'] as String,
       locale: json['locale'] as String,
-      decimalSeparator: json['decimalSeparator'] as String?,
-      thousandsSeparator: json['thousandsSeparator'] as String?,
-      currencySymbol: json['currencySymbol'] as String?,
-      currencyPosition: json['currencyPosition'] as String?,
-      sharedFeatures: (json['sharedFeatures'] as List<dynamic>?)
-          ?.map((e) => e as String)
-          .toList(),
     );
   }
 }


### PR DESCRIPTION
Adds CI workflow that regenerates Dart API types from OpenAPI spec when triggered by ign `repository_dispatch`.

**Key features:**
- Listens for `api-types-updated` event from ign spec-publish-sync workflow
- Downloads latest `openapi.yaml` from firela-app's own main branch
- Updates `build.yaml` URL from deprecated `api-specs` repo to firela-app self
- Requires Java (for openapi_generator JAR) and Dart SDK
- Runs `dart analyze lib/api/generated/` to verify compilation
- Creates PR with generated types; reports failures via Issue

**Phase:** 36 (OpenAPI Spec Dart Sync)
**Design:** Matches Phase 35 CI patterns (stable branch names, failure reporting)