### PR TITLE
ci: add sanitizer path to dart analyze workflow

### DIFF
--- a/.github/workflows/parser-dart-analyze.yml
+++ b/.github/workflows/parser-dart-analyze.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - 'lib/parser/**'
+      - 'lib/sanitizer/**'
 
 permissions:
   contents: read
@@ -26,3 +27,6 @@ jobs:
 
       - name: Analyze parser code
         run: dart analyze lib/parser/
+
+      - name: Analyze sanitizer code
+        run: dart analyze lib/sanitizer/


### PR DESCRIPTION
Add `lib/sanitizer/**` to PR trigger paths and add `dart analyze lib/sanitizer/` step.

#404