### PR TITLE
chore: community facade — new-parser template + repo clarification

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-parser.yml
+++ b/.github/ISSUE_TEMPLATE/new-parser.yml
@@ -1,0 +1,50 @@
+name: New Parser Request
+description: Request support for a new financial institution / import format
+title: "[Parser]: <Institution name> (<Region>)"
+labels: ["new-parser"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for contributing a parser! Parsers run locally as WASM on the user's
+        device — financial data never leaves the phone. A maintainer reviews each
+        request; generation runs in the private pipeline and the compiled WASM is
+        published to the `@firela/*` npm packages + CDN.
+  - type: input
+    id: institution
+    attributes:
+      label: Institution name
+      description: e.g. "China Merchants Bank", "Deutsche Bank", "HSBC"
+    validations:
+      required: true
+  - type: input
+    id: region
+    attributes:
+      label: Region (ISO 3166-1)
+      description: e.g. CN, DE, HK, US
+    validations:
+      required: true
+  - type: input
+    id: format
+    attributes:
+      label: File format
+      description: e.g. CSV, XLSX, HTML, PDF
+    validations:
+      required: true
+  - type: textarea
+    id: sample
+    attributes:
+      label: Sample transaction data
+      description: |
+        Paste 5-10 sample lines. REDACT all PII first — replace real names, account
+        numbers, and card numbers with placeholders. Unredacted PII is auto-detected
+        and the submission will be blocked.
+    validations:
+      required: true
+  - type: textarea
+    id: mapping
+    attributes:
+      label: Field mapping (optional)
+      description: How columns/fields map to transaction fields (date, amount, payee, etc.)
+    validations:
+      required: false

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 *Coming soon*
 
+> **About this repo:** This public repository hosts the open-source **API client** (`lib/api/` — OpenAPI types + Dart facade) and the community **parser contribution pipeline**. Open a [new-parser Issue](../../issues/new?labels=new-parser) to request support for a financial institution. The FIREla mobile app source code is closed. Parsers run locally as WASM on each device; financial data never leaves your phone.
+
 ## Data Sovereignty First
 
 FIREla is built on the same core principle as **Beancount**: **your financial data belongs to you**.


### PR DESCRIPTION
Adds structured new-parser Issue template and clarifies README: this public repo hosts the open API client (`lib/api/`) + community parser pipeline. App source is closed.