### PR TITLE
chore: regenerate Dart API types from OpenAPI spec

### DIFF
--- a/lib/api/generated/lib/src/model/nlp_response_dto.dart
+++ b/lib/api/generated/lib/src/model/nlp_response_dto.dart
@@ -58,7 +58,7 @@ abstract class NlpResponseDto implements Built<NlpResponseDto, NlpResponseDtoBui
   /// Action taken or requested
   @BuiltValueField(wireName: r'action')
   NlpResponseDtoActionEnum get action;
-  // enum actionEnum {  created,  ask,  confirm,  confirm_duplicate,  confirm_rule,  confirm_account,  confirm_payee,  cancel,  };
+  // enum actionEnum {  created,  ask,  confirm,  confirm_duplicate,  confirm_rule,  confirm_account,  confirm_payee,  cancel,  aborted,  };
 
   /// Transaction intent detected by EntityRouter (v6.0: 5 core intents). Frontend uses this to render scenario-specific form fields.
   @BuiltValueField(wireName: r'intent')
@@ -615,6 +615,9 @@ class NlpResponseDtoActionEnum extends EnumClass {
   /// Action taken or requested
   @BuiltValueEnumConst(wireName: r'cancel')
   static const NlpResponseDtoActionEnum cancel = _$nlpResponseDtoActionEnum_cancel;
+  /// Action taken or requested
+  @BuiltValueEnumConst(wireName: r'aborted')
+  static const NlpResponseDtoActionEnum aborted = _$nlpResponseDtoActionEnum_aborted;
 
   static Serializer<NlpResponseDtoActionEnum> get serializer => _$nlpResponseDtoActionEnumSerializer;
 

--- a/lib/api/generated/lib/src/model/nlp_response_dto.g.dart
+++ b/lib/api/generated/lib/src/model/nlp_response_dto.g.dart
@@ -49,6 +49,8 @@ const NlpResponseDtoActionEnum _$nlpResponseDtoActionEnum_confirmPayee =
     const NlpResponseDtoActionEnum._('confirmPayee');
 const NlpResponseDtoActionEnum _$nlpResponseDtoActionEnum_cancel =
     const NlpResponseDtoActionEnum._('cancel');
+const NlpResponseDtoActionEnum _$nlpResponseDtoActionEnum_aborted =
+    const NlpResponseDtoActionEnum._('aborted');
 
 NlpResponseDtoActionEnum _$nlpResponseDtoActionEnumValueOf(String name) {
   switch (name) {
@@ -68,6 +70,8 @@ NlpResponseDtoActionEnum _$nlpResponseDtoActionEnumValueOf(String name) {
       return _$nlpResponseDtoActionEnum_confirmPayee;
     case 'cancel':
       return _$nlpResponseDtoActionEnum_cancel;
+    case 'aborted':
+      return _$nlpResponseDtoActionEnum_aborted;
     default:
       throw new ArgumentError(name);
   }
@@ -83,6 +87,7 @@ final BuiltSet<NlpResponseDtoActionEnum> _$nlpResponseDtoActionEnumValues =
   _$nlpResponseDtoActionEnum_confirmAccount,
   _$nlpResponseDtoActionEnum_confirmPayee,
   _$nlpResponseDtoActionEnum_cancel,
+  _$nlpResponseDtoActionEnum_aborted,
 ]);
 
 const NlpResponseDtoIntentEnum _$nlpResponseDtoIntentEnum_expense =
@@ -290,6 +295,7 @@ class _$NlpResponseDtoActionEnumSerializer
     'confirmAccount': 'confirm_account',
     'confirmPayee': 'confirm_payee',
     'cancel': 'cancel',
+    'aborted': 'aborted',
   };
   static const Map<Object, String> _fromWire = const <Object, String>{
     'created': 'created',
@@ -300,6 +306,7 @@ class _$NlpResponseDtoActionEnumSerializer
     'confirm_account': 'confirmAccount',
     'confirm_payee': 'confirmPayee',
     'cancel': 'cancel',
+    'aborted': 'aborted',
   };
 
   @override


### PR DESCRIPTION
Auto-regenerated Dart API types from OpenAPI spec.

**Trigger:** ign@19a65e42d9ccd8bddb33383ffe9e425441c4e79b