### PR TITLE
chore: regenerate Dart API types from OpenAPI spec

### DIFF
--- a/lib/api/generated/lib/src/model/nlp_account_confirmation_data_dto.dart
+++ b/lib/api/generated/lib/src/model/nlp_account_confirmation_data_dto.dart
@@ -14,7 +14,7 @@ part 'nlp_account_confirmation_data_dto.g.dart';
 ///
 /// Properties:
 /// * [invalidAccount] - The invalid account name
-/// * [suggestedAccount] - Suggested replacement account
+/// * [suggestedAccount] - Suggested replacement account (omitted when no clear candidate)
 /// * [similarAccounts] - Similar accounts for user selection
 /// * [errorMessage] - Error message explaining the issue
 /// * [transactionContext] - Transaction context for reference
@@ -24,9 +24,9 @@ abstract class NlpAccountConfirmationDataDto implements Built<NlpAccountConfirma
   @BuiltValueField(wireName: r'invalidAccount')
   String get invalidAccount;
 
-  /// Suggested replacement account
+  /// Suggested replacement account (omitted when no clear candidate)
   @BuiltValueField(wireName: r'suggestedAccount')
-  String get suggestedAccount;
+  String? get suggestedAccount;
 
   /// Similar accounts for user selection
   @BuiltValueField(wireName: r'similarAccounts')
@@ -68,11 +68,13 @@ class _$NlpAccountConfirmationDataDtoSerializer implements PrimitiveSerializer<N
       object.invalidAccount,
       specifiedType: const FullType(String),
     );
-    yield r'suggestedAccount';
-    yield serializers.serialize(
-      object.suggestedAccount,
-      specifiedType: const FullType(String),
-    );
+    if (object.suggestedAccount != null) {
+      yield r'suggestedAccount';
+      yield serializers.serialize(
+        object.suggestedAccount,
+        specifiedType: const FullType(String),
+      );
+    }
     yield r'similarAccounts';
     yield serializers.serialize(
       object.similarAccounts,

--- a/lib/api/generated/lib/src/model/nlp_account_confirmation_data_dto.g.dart
+++ b/lib/api/generated/lib/src/model/nlp_account_confirmation_data_dto.g.dart
@@ -10,7 +10,7 @@ class _$NlpAccountConfirmationDataDto extends NlpAccountConfirmationDataDto {
   @override
   final String invalidAccount;
   @override
-  final String suggestedAccount;
+  final String? suggestedAccount;
   @override
   final BuiltList<String> similarAccounts;
   @override
@@ -24,15 +24,13 @@ class _$NlpAccountConfirmationDataDto extends NlpAccountConfirmationDataDto {
 
   _$NlpAccountConfirmationDataDto._(
       {required this.invalidAccount,
-      required this.suggestedAccount,
+      this.suggestedAccount,
       required this.similarAccounts,
       required this.errorMessage,
       required this.transactionContext})
       : super._() {
     BuiltValueNullFieldError.checkNotNull(
         invalidAccount, r'NlpAccountConfirmationDataDto', 'invalidAccount');
-    BuiltValueNullFieldError.checkNotNull(
-        suggestedAccount, r'NlpAccountConfirmationDataDto', 'suggestedAccount');
     BuiltValueNullFieldError.checkNotNull(
         similarAccounts, r'NlpAccountConfirmationDataDto', 'similarAccounts');
     BuiltValueNullFieldError.checkNotNull(
@@ -156,10 +154,7 @@ class NlpAccountConfirmationDataDtoBuilder
                   invalidAccount,
                   r'NlpAccountConfirmationDataDto',
                   'invalidAccount'),
-              suggestedAccount: BuiltValueNullFieldError.checkNotNull(
-                  suggestedAccount,
-                  r'NlpAccountConfirmationDataDto',
-                  'suggestedAccount'),
+              suggestedAccount: suggestedAccount,
               similarAccounts: similarAccounts.build(),
               errorMessage: BuiltValueNullFieldError.checkNotNull(errorMessage,
                   r'NlpAccountConfirmationDataDto', 'errorMessage'),


### PR DESCRIPTION
Auto-regenerated Dart API types from OpenAPI spec.

**Trigger:** ign@f67628018754e354886f6368a97623467870d981