### PR TITLE
chore(ci): clean generated output dir before openapi-generator run

### DIFF
--- a/.github/workflows/regenerate-api-types.yml
+++ b/.github/workflows/regenerate-api-types.yml
@@ -57,6 +57,12 @@ jobs:
             "https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/7.2.0/openapi-generator-cli-7.2.0.jar"
           test -s openapi-generator-cli.jar && echo "JAR downloaded: $(ls -la openapi-generator-cli.jar)"
 
+      # Clean output dir so paths removed from the spec don't survive as orphan files.
+      # openapi-generator overlays; without this, deleted endpoints (e.g. /market/symbols/*
+      # removed in firela-vlt#421) persist across regens.
+      - name: Clean generated output
+        run: rm -rf lib/api/generated
+
       # Generate model .dart files directly with stock dart-dio 7.2.0 (matches the
       # committed models → minimal diff). pubName matches the firela_api package; dart-dio
       # defaults to built_value serialization. build_runner below regenerates the .g.dart


### PR DESCRIPTION
## Problem

`firela_api` (the generated Dart client) still exposes `SymbolsApi`, `MarketDataApi`, and `LogosApi` even though the backing endpoints were removed from the OpenAPI spec long ago (`/market/symbols/*`, `/market-data/*`, logos — all removed in firela-vlt#421, 2026-05-07).

Root cause: `openapi-generator-cli generate -o lib/api/generated` **overlays** files — it does not delete paths that no longer exist in the spec. With no clean step, orphan files from pre-#421 generations persist across every regen. Confirmed: `symbols_api.dart` / `market_data_api.dart` / `logos_api.dart` were last touched 2026-04-14 and survived every regen since (including today's).

This blocks firela-vlt#578 — the frontend consumes `firela_api` via git dep and cannot drop the stale `SymbolsApi` until these orphans are regenerated away.

## Fix

Add one step before the generate step:

```yaml
- name: Clean generated output
  run: rm -rf lib/api/generated
```

Safe because every file under `lib/api/generated/` is either regenerated by openapi-generator or recreated by a later step in this same workflow (`analysis_options.yaml` written each run, `pubspec.yaml` SDK patched each run, `.g.dart` rebuilt by build_runner). No hand-maintained files live there.

## Verification (after merge + one regen dispatch)

`lib/api/generated/lib/src/api/` no longer lists `symbols_api.dart`, `market_data_api.dart`, `logos_api.dart`. Every remaining `*_api.dart` corresponds to a tag in `lib/api/spec/openapi.yaml`.

## Follow-up

After merge, a `workflow_dispatch` run of "Regenerate API Types" will produce a `sync/api-types` PR that deletes the orphans. Frontend then bumps the `firela_api` git ref + `flutter pub get`.

Refs: fire-zu/firela-vlt#578