### PR TITLE
chore: regenerate Dart API types from OpenAPI spec

### DIFF
--- a/lib/api/generated/lib/src/model/nlp_suggested_account_dto.dart
+++ b/lib/api/generated/lib/src/model/nlp_suggested_account_dto.dart
@@ -12,14 +12,14 @@ part 'nlp_suggested_account_dto.g.dart';
 ///
 /// Properties:
 /// * [account] - Suggested account path
-/// * [confidence] - Confidence score for this suggestion (0-1)
+/// * [confidence] - Confidence score for this suggestion (0-1). Present = predicted (confirm/confirm_rule/confirm_account); omitted = actual persisted account (created). (#586)
 @BuiltValue()
 abstract class NlpSuggestedAccountDto implements Built<NlpSuggestedAccountDto, NlpSuggestedAccountDtoBuilder> {
   /// Suggested account path
   @BuiltValueField(wireName: r'account')
   String get account;
 
-  /// Confidence score for this suggestion (0-1)
+  /// Confidence score for this suggestion (0-1). Present = predicted (confirm/confirm_rule/confirm_account); omitted = actual persisted account (created). (#586)
   @BuiltValueField(wireName: r'confidence')
   num? get confidence;
 


### PR DESCRIPTION
Auto-regenerated Dart API types from OpenAPI spec.

**Trigger:** ign@c47f91c3a2561f2c98e008b14dd74512dec4e522