### PR TITLE
chore: regenerate Dart API types from OpenAPI spec

### DIFF
--- a/lib/api/generated/lib/src/api/bean_accounts_api.dart
+++ b/lib/api/generated/lib/src/api/bean_accounts_api.dart
@@ -321,7 +321,7 @@ class BeanAccountsApi {
   }
 
   /// Delete account
-  /// Deletes an account (only if no transactions)
+  /// Deletes an account (only if no active transactions; voided/superseded residual postings are cleaned up)
   ///
   /// Parameters:
   /// * [id] - Account UUID


### PR DESCRIPTION
Auto-regenerated Dart API types from OpenAPI spec.

**Trigger:** ign@06774fc74c2ec9c0571fa5681c2dadd40bd53c69