### PR TITLE
chore: regenerate Dart API types from OpenAPI spec

### DIFF
--- a/lib/api/generated/lib/src/model/provider_sync_config_dto.dart
+++ b/lib/api/generated/lib/src/model/provider_sync_config_dto.dart
@@ -13,8 +13,8 @@ part 'provider_sync_config_dto.g.dart';
 /// Properties:
 /// * [sourceAccount] - Source account for the first posting
 /// * [defaultCurrency] - Default currency for transactions
-/// * [defaultExpenseAccount] - Default expense account for the second posting
-/// * [defaultIncomeAccount] - Default income account for the second posting
+/// * [defaultExpenseAccount] - Default expense account for the second posting. Omit when no real default exists; the pipeline routes to Review via the Uncategorized sentinel (#618).
+/// * [defaultIncomeAccount] - Default income account for the second posting. Omit when no real default exists; the pipeline routes to Review via the Uncategorized sentinel (#618).
 /// * [filterPending] - Filter pending transactions
 /// * [externalAccountId] - External account ID for per-batch providers (e.g. GoCardless). Overrides sourceAccount when an ExternalAccountLink mapping exists.
 @BuiltValue()
@@ -27,13 +27,13 @@ abstract class ProviderSyncConfigDto implements Built<ProviderSyncConfigDto, Pro
   @BuiltValueField(wireName: r'defaultCurrency')
   String get defaultCurrency;
 
-  /// Default expense account for the second posting
+  /// Default expense account for the second posting. Omit when no real default exists; the pipeline routes to Review via the Uncategorized sentinel (#618).
   @BuiltValueField(wireName: r'defaultExpenseAccount')
-  String get defaultExpenseAccount;
+  String? get defaultExpenseAccount;
 
-  /// Default income account for the second posting
+  /// Default income account for the second posting. Omit when no real default exists; the pipeline routes to Review via the Uncategorized sentinel (#618).
   @BuiltValueField(wireName: r'defaultIncomeAccount')
-  String get defaultIncomeAccount;
+  String? get defaultIncomeAccount;
 
   /// Filter pending transactions
   @BuiltValueField(wireName: r'filterPending')
@@ -77,16 +77,20 @@ class _$ProviderSyncConfigDtoSerializer implements PrimitiveSerializer<ProviderS
       object.defaultCurrency,
       specifiedType: const FullType(String),
     );
-    yield r'defaultExpenseAccount';
-    yield serializers.serialize(
-      object.defaultExpenseAccount,
-      specifiedType: const FullType(String),
-    );
-    yield r'defaultIncomeAccount';
-    yield serializers.serialize(
-      object.defaultIncomeAccount,
-      specifiedType: const FullType(String),
-    );
+    if (object.defaultExpenseAccount != null) {
+      yield r'defaultExpenseAccount';
+      yield serializers.serialize(
+        object.defaultExpenseAccount,
+        specifiedType: const FullType(String),
+      );
+    }
+    if (object.defaultIncomeAccount != null) {
+      yield r'defaultIncomeAccount';
+      yield serializers.serialize(
+        object.defaultIncomeAccount,
+        specifiedType: const FullType(String),
+      );
+    }
     if (object.filterPending != null) {
       yield r'filterPending';
       yield serializers.serialize(

--- a/lib/api/generated/lib/src/model/provider_sync_config_dto.g.dart
+++ b/lib/api/generated/lib/src/model/provider_sync_config_dto.g.dart
@@ -12,9 +12,9 @@ class _$ProviderSyncConfigDto extends ProviderSyncConfigDto {
   @override
   final String defaultCurrency;
   @override
-  final String defaultExpenseAccount;
+  final String? defaultExpenseAccount;
   @override
-  final String defaultIncomeAccount;
+  final String? defaultIncomeAccount;
   @override
   final bool? filterPending;
   @override
@@ -27,8 +27,8 @@ class _$ProviderSyncConfigDto extends ProviderSyncConfigDto {
   _$ProviderSyncConfigDto._(
       {required this.sourceAccount,
       required this.defaultCurrency,
-      required this.defaultExpenseAccount,
-      required this.defaultIncomeAccount,
+      this.defaultExpenseAccount,
+      this.defaultIncomeAccount,
       this.filterPending,
       this.externalAccountId})
       : super._() {
@@ -36,10 +36,6 @@ class _$ProviderSyncConfigDto extends ProviderSyncConfigDto {
         sourceAccount, r'ProviderSyncConfigDto', 'sourceAccount');
     BuiltValueNullFieldError.checkNotNull(
         defaultCurrency, r'ProviderSyncConfigDto', 'defaultCurrency');
-    BuiltValueNullFieldError.checkNotNull(defaultExpenseAccount,
-        r'ProviderSyncConfigDto', 'defaultExpenseAccount');
-    BuiltValueNullFieldError.checkNotNull(
-        defaultIncomeAccount, r'ProviderSyncConfigDto', 'defaultIncomeAccount');
   }
 
   @override
@@ -162,14 +158,8 @@ class ProviderSyncConfigDtoBuilder
                 sourceAccount, r'ProviderSyncConfigDto', 'sourceAccount'),
             defaultCurrency: BuiltValueNullFieldError.checkNotNull(
                 defaultCurrency, r'ProviderSyncConfigDto', 'defaultCurrency'),
-            defaultExpenseAccount: BuiltValueNullFieldError.checkNotNull(
-                defaultExpenseAccount,
-                r'ProviderSyncConfigDto',
-                'defaultExpenseAccount'),
-            defaultIncomeAccount: BuiltValueNullFieldError.checkNotNull(
-                defaultIncomeAccount,
-                r'ProviderSyncConfigDto',
-                'defaultIncomeAccount'),
+            defaultExpenseAccount: defaultExpenseAccount,
+            defaultIncomeAccount: defaultIncomeAccount,
             filterPending: filterPending,
             externalAccountId: externalAccountId);
     replace(_$result);


### PR DESCRIPTION
Auto-regenerated Dart API types from OpenAPI spec.

**Trigger:** ign@cdf271d11f8716e32063771834ab3d70c372b8df