### PR TITLE
chore: regenerate Dart API types from OpenAPI spec

### DIFF
--- a/lib/api/generated/lib/src/model/platform_list_item_dto.dart
+++ b/lib/api/generated/lib/src/model/platform_list_item_dto.dart
@@ -17,7 +17,7 @@ part 'platform_list_item_dto.g.dart';
 /// * [url] - Platform URL
 /// * [type] - Platform type
 /// * [canonical] - Canonical identifier in ACCOUNT_RE format (e.g., \"icbc\")
-/// * [suggestedSegment] - Suggested path segment — canonical with first char uppercased (ACC_COMP_NAME_RE)
+/// * [suggestedSegment] - Suggested path segment — PascalCase of canonical, hyphens removed (e.g. \"ApplePay\")
 /// * [logoUrl] - Logo URL
 /// * [countryCode] - ISO 3166-1 alpha-2 (UPPERCASE); null = global platform
 /// * [category] - Region-aware category (institution vocab, e.g. DigitalWallet/Bank). null = no region-aware suggestion; fall back to type.
@@ -45,7 +45,7 @@ abstract class PlatformListItemDto implements Built<PlatformListItemDto, Platfor
   @BuiltValueField(wireName: r'canonical')
   String get canonical;
 
-  /// Suggested path segment — canonical with first char uppercased (ACC_COMP_NAME_RE)
+  /// Suggested path segment — PascalCase of canonical, hyphens removed (e.g. \"ApplePay\")
   @BuiltValueField(wireName: r'suggestedSegment')
   String get suggestedSegment;
 

--- a/lib/api/generated/lib/src/model/platform_match_result_dto.dart
+++ b/lib/api/generated/lib/src/model/platform_match_result_dto.dart
@@ -16,7 +16,7 @@ part 'platform_match_result_dto.g.dart';
 /// * [name] - Platform name (e.g., \"ICBC\")
 /// * [canonical] - Canonical identifier in ACCOUNT_RE format (e.g., \"icbc\")
 /// * [type] - Platform type
-/// * [suggestedSegment] - Suggested path segment — canonical, already in ACCOUNT_RE format
+/// * [suggestedSegment] - Suggested path segment — PascalCase of canonical, hyphens removed (e.g. \"ApplePay\")
 /// * [logoUrl] - Logo URL
 /// * [countryCode] - ISO 3166-1 alpha-2 (UPPERCASE); null = global platform
 /// * [category] - Region-aware category (institution vocab, e.g. DigitalWallet/Bank). null = no region-aware suggestion; fall back to type.
@@ -40,7 +40,7 @@ abstract class PlatformMatchResultDto implements Built<PlatformMatchResultDto, P
   PlatformMatchResultDtoTypeEnum get type;
   // enum typeEnum {  BANK,  BROKERAGE,  CRYPTO_EXCHANGE,  PAYMENT,  INVESTMENT,  INSURANCE,  OTHER,  };
 
-  /// Suggested path segment — canonical, already in ACCOUNT_RE format
+  /// Suggested path segment — PascalCase of canonical, hyphens removed (e.g. \"ApplePay\")
   @BuiltValueField(wireName: r'suggestedSegment')
   String get suggestedSegment;
 


### PR DESCRIPTION
Auto-regenerated Dart API types from OpenAPI spec.

**Trigger:** ign@8d45b2d340303d1dcab18fd2eaa6af582ebd6949