### PR TITLE
chore: regenerate Dart API types from OpenAPI spec

### DIFF
--- a/lib/api/generated/lib/src/model/parser_contribution_samples_dto.dart
+++ b/lib/api/generated/lib/src/model/parser_contribution_samples_dto.dart
@@ -4,6 +4,7 @@
 
 // ignore_for_file: unused_element
 import 'package:built_collection/built_collection.dart';
+import 'package:built_value/json_object.dart';
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 
@@ -18,7 +19,7 @@ part 'parser_contribution_samples_dto.g.dart';
 abstract class ParserContributionSamplesDto implements Built<ParserContributionSamplesDto, ParserContributionSamplesDtoBuilder> {
   /// Client-sanitized sample rows (key = column name, value = cell)
   @BuiltValueField(wireName: r'rows')
-  BuiltList<String> get rows;
+  BuiltList<JsonObject> get rows;
 
   @BuiltValueField(wireName: r'rawHeaders')
   BuiltList<String>? get rawHeaders;
@@ -49,7 +50,7 @@ class _$ParserContributionSamplesDtoSerializer implements PrimitiveSerializer<Pa
     yield r'rows';
     yield serializers.serialize(
       object.rows,
-      specifiedType: const FullType(BuiltList, [FullType(String)]),
+      specifiedType: const FullType(BuiltList, [FullType(JsonObject)]),
     );
     if (object.rawHeaders != null) {
       yield r'rawHeaders';
@@ -84,8 +85,8 @@ class _$ParserContributionSamplesDtoSerializer implements PrimitiveSerializer<Pa
         case r'rows':
           final valueDes = serializers.deserialize(
             value,
-            specifiedType: const FullType(BuiltList, [FullType(String)]),
-          ) as BuiltList<String>;
+            specifiedType: const FullType(BuiltList, [FullType(JsonObject)]),
+          ) as BuiltList<JsonObject>;
           result.rows.replace(valueDes);
           break;
         case r'rawHeaders':

--- a/lib/api/generated/lib/src/model/parser_contribution_samples_dto.g.dart
+++ b/lib/api/generated/lib/src/model/parser_contribution_samples_dto.g.dart
@@ -8,7 +8,7 @@ part of 'parser_contribution_samples_dto.dart';
 
 class _$ParserContributionSamplesDto extends ParserContributionSamplesDto {
   @override
-  final BuiltList<String> rows;
+  final BuiltList<JsonObject> rows;
   @override
   final BuiltList<String>? rawHeaders;
 
@@ -63,9 +63,10 @@ class ParserContributionSamplesDtoBuilder
             ParserContributionSamplesDtoBuilder> {
   _$ParserContributionSamplesDto? _$v;
 
-  ListBuilder<String>? _rows;
-  ListBuilder<String> get rows => _$this._rows ??= new ListBuilder<String>();
-  set rows(ListBuilder<String>? rows) => _$this._rows = rows;
+  ListBuilder<JsonObject>? _rows;
+  ListBuilder<JsonObject> get rows =>
+      _$this._rows ??= new ListBuilder<JsonObject>();
+  set rows(ListBuilder<JsonObject>? rows) => _$this._rows = rows;
 
   ListBuilder<String>? _rawHeaders;
   ListBuilder<String> get rawHeaders =>

--- a/lib/api/generated/lib/src/serializers.g.dart
+++ b/lib/api/generated/lib/src/serializers.g.dart
@@ -563,6 +563,12 @@ Serializers _$serializers = (new Serializers().toBuilder()
           const FullType(BuiltList, const [const FullType(JsonObject)]),
           () => new ListBuilder<JsonObject>())
       ..addBuilderFactory(
+          const FullType(BuiltList, const [const FullType(JsonObject)]),
+          () => new ListBuilder<JsonObject>())
+      ..addBuilderFactory(
+          const FullType(BuiltList, const [const FullType(String)]),
+          () => new ListBuilder<String>())
+      ..addBuilderFactory(
           const FullType(BuiltList, const [const FullType(MonthlyForecastDto)]),
           () => new ListBuilder<MonthlyForecastDto>())
       ..addBuilderFactory(
@@ -612,12 +618,6 @@ Serializers _$serializers = (new Serializers().toBuilder()
           const FullType(BuiltList,
               const [const FullType(RuleStatisticsResponseDtoRuleStatsInner)]),
           () => new ListBuilder<RuleStatisticsResponseDtoRuleStatsInner>())
-      ..addBuilderFactory(
-          const FullType(BuiltList, const [const FullType(String)]),
-          () => new ListBuilder<String>())
-      ..addBuilderFactory(
-          const FullType(BuiltList, const [const FullType(String)]),
-          () => new ListBuilder<String>())
       ..addBuilderFactory(
           const FullType(BuiltList, const [const FullType(String)]),
           () => new ListBuilder<String>())


### PR DESCRIPTION
Auto-regenerated Dart API types from OpenAPI spec.

**Trigger:** ign@268478748995c368fbdc1c4917adf8b6fa7e2d3a