### PR TITLE
chore: sync OpenAPI spec from ign@421ffa2c18310c0669d7331722b19c7db05f2c5f

### DIFF
--- a/lib/api/spec/openapi.yaml
+++ b/lib/api/spec/openapi.yaml
@@ -16069,7 +16069,7 @@ components:
       properties:
         issueUrl:
           type: string
-          example: https://github.com/fire-la/parsers/issues/42
+          example: https://github.com/fire-zu/firela-vlt/issues/42
         issueNumber:
           type: number
           example: 42


### PR DESCRIPTION
Auto-synced OpenAPI spec from ign repository.

**Source:** fire-zu/firela-vlt@421ffa2c18310c0669d7331722b19c7db05f2c5f