### PR TITLE
chore: regenerate Dart API types from OpenAPI spec

### DIFF
--- a/lib/api/generated/lib/src/model/account_standard_response_dto.dart
+++ b/lib/api/generated/lib/src/model/account_standard_response_dto.dart
@@ -14,10 +14,11 @@ part 'account_standard_response_dto.g.dart';
 /// Properties:
 /// * [path] - Account path (hierarchical, colon-separated)
 /// * [type] - Account type in Beancount hierarchy
-/// * [name] - Short localized display name
+/// * [name] - Short display name. Universal rows project to the request locale (Accept-Language); regional rows keep the authored native name — mixed-language by design (ADR-0131 class P vs class A).
 /// * [aliases] - Authored market-language alternative names delivered verbatim (not localized copy, not xlf-managed, not locale-projected). Flat string[] per ADR-0129 D1; ADR-0131 class A.
-/// * [description] - Account description (stable semantics only)
-/// * [tags] - Account tags for categorization
+/// * [searchTerms] - Locale-projected search synonyms (e.g. the zh bank-card / debit-card everyday terms for the checking account). Pure-locale projection — absent when the locale has no seeded synonyms; English fallback rides the authored aliases field. Search-only vocabulary, not the NLP routing corpus (#698, ADR-0131 fourth-class adjudication).
+/// * [description] - Account description (stable semantics only). Mixed-language contract: universal rows deliver authored English verbatim today (ADR-0131 class P, zero translations is expected); regional rows deliver the authored market language (ADR-0131 class A, verbatim).
+/// * [tags] - Account tags for categorization — structured metadata delivered verbatim (not localized, not xlf-managed). ADR-0131 class A.
 /// * [icon] - Icon identifier for UI display
 /// * [productCategory] - Onboarding product category (coarse grouping derived from assetSubClass)
 /// * [assetClass] - Asset class (LIQUIDITY/EQUITY/.../LIABILITY), derived at read time from classification rules
@@ -33,7 +34,7 @@ abstract class AccountStandardResponseDto implements Built<AccountStandardRespon
   AccountStandardResponseDtoTypeEnum get type;
   // enum typeEnum {  Assets,  Liabilities,  Income,  Expenses,  Equity,  };
 
-  /// Short localized display name
+  /// Short display name. Universal rows project to the request locale (Accept-Language); regional rows keep the authored native name — mixed-language by design (ADR-0131 class P vs class A).
   @BuiltValueField(wireName: r'name')
   String? get name;
 
@@ -41,11 +42,15 @@ abstract class AccountStandardResponseDto implements Built<AccountStandardRespon
   @BuiltValueField(wireName: r'aliases')
   BuiltList<String>? get aliases;
 
-  /// Account description (stable semantics only)
+  /// Locale-projected search synonyms (e.g. the zh bank-card / debit-card everyday terms for the checking account). Pure-locale projection — absent when the locale has no seeded synonyms; English fallback rides the authored aliases field. Search-only vocabulary, not the NLP routing corpus (#698, ADR-0131 fourth-class adjudication).
+  @BuiltValueField(wireName: r'searchTerms')
+  BuiltList<String>? get searchTerms;
+
+  /// Account description (stable semantics only). Mixed-language contract: universal rows deliver authored English verbatim today (ADR-0131 class P, zero translations is expected); regional rows deliver the authored market language (ADR-0131 class A, verbatim).
   @BuiltValueField(wireName: r'description')
   String get description;
 
-  /// Account tags for categorization
+  /// Account tags for categorization — structured metadata delivered verbatim (not localized, not xlf-managed). ADR-0131 class A.
   @BuiltValueField(wireName: r'tags')
   BuiltList<String> get tags;
 
@@ -111,6 +116,13 @@ class _$AccountStandardResponseDtoSerializer implements PrimitiveSerializer<Acco
       yield r'aliases';
       yield serializers.serialize(
         object.aliases,
+        specifiedType: const FullType(BuiltList, [FullType(String)]),
+      );
+    }
+    if (object.searchTerms != null) {
+      yield r'searchTerms';
+      yield serializers.serialize(
+        object.searchTerms,
         specifiedType: const FullType(BuiltList, [FullType(String)]),
       );
     }
@@ -198,6 +210,13 @@ class _$AccountStandardResponseDtoSerializer implements PrimitiveSerializer<Acco
             specifiedType: const FullType(BuiltList, [FullType(String)]),
           ) as BuiltList<String>;
           result.aliases.replace(valueDes);
+          break;
+        case r'searchTerms':
+          final valueDes = serializers.deserialize(
+            value,
+            specifiedType: const FullType(BuiltList, [FullType(String)]),
+          ) as BuiltList<String>;
+          result.searchTerms.replace(valueDes);
           break;
         case r'description':
           final valueDes = serializers.deserialize(

--- a/lib/api/generated/lib/src/model/account_standard_response_dto.g.dart
+++ b/lib/api/generated/lib/src/model/account_standard_response_dto.g.dart
@@ -327,6 +327,8 @@ class _$AccountStandardResponseDto extends AccountStandardResponseDto {
   @override
   final BuiltList<String>? aliases;
   @override
+  final BuiltList<String>? searchTerms;
+  @override
   final String description;
   @override
   final BuiltList<String> tags;
@@ -348,6 +350,7 @@ class _$AccountStandardResponseDto extends AccountStandardResponseDto {
       required this.type,
       this.name,
       this.aliases,
+      this.searchTerms,
       required this.description,
       required this.tags,
       required this.icon,
@@ -386,6 +389,7 @@ class _$AccountStandardResponseDto extends AccountStandardResponseDto {
         type == other.type &&
         name == other.name &&
         aliases == other.aliases &&
+        searchTerms == other.searchTerms &&
         description == other.description &&
         tags == other.tags &&
         icon == other.icon &&
@@ -401,6 +405,7 @@ class _$AccountStandardResponseDto extends AccountStandardResponseDto {
     _$hash = $jc(_$hash, type.hashCode);
     _$hash = $jc(_$hash, name.hashCode);
     _$hash = $jc(_$hash, aliases.hashCode);
+    _$hash = $jc(_$hash, searchTerms.hashCode);
     _$hash = $jc(_$hash, description.hashCode);
     _$hash = $jc(_$hash, tags.hashCode);
     _$hash = $jc(_$hash, icon.hashCode);
@@ -418,6 +423,7 @@ class _$AccountStandardResponseDto extends AccountStandardResponseDto {
           ..add('type', type)
           ..add('name', name)
           ..add('aliases', aliases)
+          ..add('searchTerms', searchTerms)
           ..add('description', description)
           ..add('tags', tags)
           ..add('icon', icon)
@@ -449,6 +455,12 @@ class AccountStandardResponseDtoBuilder
   ListBuilder<String> get aliases =>
       _$this._aliases ??= new ListBuilder<String>();
   set aliases(ListBuilder<String>? aliases) => _$this._aliases = aliases;
+
+  ListBuilder<String>? _searchTerms;
+  ListBuilder<String> get searchTerms =>
+      _$this._searchTerms ??= new ListBuilder<String>();
+  set searchTerms(ListBuilder<String>? searchTerms) =>
+      _$this._searchTerms = searchTerms;
 
   String? _description;
   String? get description => _$this._description;
@@ -491,6 +503,7 @@ class AccountStandardResponseDtoBuilder
       _type = $v.type;
       _name = $v.name;
       _aliases = $v.aliases?.toBuilder();
+      _searchTerms = $v.searchTerms?.toBuilder();
       _description = $v.description;
       _tags = $v.tags.toBuilder();
       _icon = $v.icon;
@@ -527,6 +540,7 @@ class AccountStandardResponseDtoBuilder
                   type, r'AccountStandardResponseDto', 'type'),
               name: name,
               aliases: _aliases?.build(),
+              searchTerms: _searchTerms?.build(),
               description: BuiltValueNullFieldError.checkNotNull(
                   description, r'AccountStandardResponseDto', 'description'),
               tags: tags.build(),
@@ -543,6 +557,8 @@ class AccountStandardResponseDtoBuilder
       try {
         _$failedField = 'aliases';
         _aliases?.build();
+        _$failedField = 'searchTerms';
+        _searchTerms?.build();
 
         _$failedField = 'tags';
         tags.build();

--- a/lib/api/generated/lib/src/serializers.g.dart
+++ b/lib/api/generated/lib/src/serializers.g.dart
@@ -704,12 +704,6 @@ Serializers _$serializers = (new Serializers().toBuilder()
           const FullType(BuiltList, const [const FullType(String)]),
           () => new ListBuilder<String>())
       ..addBuilderFactory(
-          const FullType(BuiltList, const [const FullType(String)]),
-          () => new ListBuilder<String>())
-      ..addBuilderFactory(
-          const FullType(BuiltList, const [const FullType(String)]),
-          () => new ListBuilder<String>())
-      ..addBuilderFactory(
           const FullType(BuiltList, const [const FullType(CreatePostingDto)]),
           () => new ListBuilder<CreatePostingDto>())
       ..addBuilderFactory(
@@ -739,6 +733,15 @@ Serializers _$serializers = (new Serializers().toBuilder()
       ..addBuilderFactory(
           const FullType(BuiltList, const [const FullType(PostingDetailDto)]),
           () => new ListBuilder<PostingDetailDto>())
+      ..addBuilderFactory(
+          const FullType(BuiltList, const [const FullType(String)]),
+          () => new ListBuilder<String>())
+      ..addBuilderFactory(
+          const FullType(BuiltList, const [const FullType(String)]),
+          () => new ListBuilder<String>())
+      ..addBuilderFactory(
+          const FullType(BuiltList, const [const FullType(String)]),
+          () => new ListBuilder<String>())
       ..addBuilderFactory(
           const FullType(BuiltList, const [const FullType(String)]),
           () => new ListBuilder<String>())


### PR DESCRIPTION
Auto-regenerated Dart API types from OpenAPI spec.

**Trigger:** ign@ba775ee47392734ffd5e1a7bd9f82dbbff58fc2b