### PR TITLE
chore: sync OpenAPI spec from ign@09445b4ba9b212d97e57aa65f8e2510ad96823c1

### DIFF
--- a/lib/api/spec/openapi.yaml
+++ b/lib/api/spec/openapi.yaml
@@ -9316,6 +9316,10 @@ components:
         locale:
           type: string
           example: de-DE
+          pattern: ^[a-z]{2,8}-[A-Z]{2}$
+          description: >-
+            Region-qualified BCP-47 tag whose region subtag equals the region's
+            own ISO 3166-1 code (e.g., ja-JP, zh-CN, en-HK)
       required:
         - currency
         - dateFormat


### PR DESCRIPTION
Auto-synced OpenAPI spec from ign repository.

**Source:** fire-zu/firela-vlt@09445b4ba9b212d97e57aa65f8e2510ad96823c1