### PR TITLE
chore: regenerate Dart API types from OpenAPI spec

### DIFF
--- a/lib/api/generated/lib/src/model/region_config_dto.dart
+++ b/lib/api/generated/lib/src/model/region_config_dto.dart
@@ -13,7 +13,7 @@ part 'region_config_dto.g.dart';
 /// Properties:
 /// * [currency] 
 /// * [dateFormat] 
-/// * [locale] 
+/// * [locale] - Region-qualified BCP-47 tag whose region subtag equals the region's own ISO 3166-1 code (e.g., ja-JP, zh-CN, en-HK)
 @BuiltValue()
 abstract class RegionConfigDto implements Built<RegionConfigDto, RegionConfigDtoBuilder> {
   @BuiltValueField(wireName: r'currency')
@@ -22,6 +22,7 @@ abstract class RegionConfigDto implements Built<RegionConfigDto, RegionConfigDto
   @BuiltValueField(wireName: r'dateFormat')
   String get dateFormat;
 
+  /// Region-qualified BCP-47 tag whose region subtag equals the region's own ISO 3166-1 code (e.g., ja-JP, zh-CN, en-HK)
   @BuiltValueField(wireName: r'locale')
   String get locale;
 


### PR DESCRIPTION
Auto-regenerated Dart API types from OpenAPI spec.

**Trigger:** ign@4deebc483a1b274224bbfe3501e73e04461e48ea