### PR TITLE
chore: regenerate Dart API types from OpenAPI spec

### DIFF
--- a/lib/api/generated/README.md
+++ b/lib/api/generated/README.md
@@ -69,7 +69,14 @@ Current version: **v1**. All paths are prefixed with `/api/v1`
 
 All Bean module endpoints require a lowercase ISO 3166-1 alpha-2 region prefix
 in the URL path. See `GET /{region}/bean/account-standards/regions` for the
-full list of open regions and their metadata (currency, locale, display name).
+full region catalog (every ISO 3166-1 entry) with an `open` flag plus display
+name and config (currency, locale) per region — open regions carry their
+loaded template config, not-yet-open regions carry registry identity fields.
+
+Not-yet-open region codes are accepted by the account-standards catalog and
+onboarding routes, where they degrade to the universal-only template catalog
+(#759, mirroring the /platforms/:id/standards fallback of #706). All other
+region-scoped routes still expect open region codes.
 
 Example: GET /api/v1/cn/bean/accounts
 

--- a/lib/api/generated/lib/src/api/bean_account_standards_api.dart
+++ b/lib/api/generated/lib/src/api/bean_account_standards_api.dart
@@ -21,10 +21,10 @@ class BeanAccountStandardsApi {
   const BeanAccountStandardsApi(this._dio, this._serializers);
 
   /// Get available regions with hierarchy
-  /// Returns supported regions with inheritance metadata
+  /// Returns the full region catalog (every ISO 3166-1 entry) with an &#39;open&#39; flag and inheritance metadata (#759)
   ///
   /// Parameters:
-  /// * [region] - Region code for tenant context
+  /// * [region] - Region code for tenant context. Not-yet-open codes degrade to the universal-only catalog (#759)
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
   /// * [extras] - Can be used to add flags to the request
@@ -99,7 +99,7 @@ class BeanAccountStandardsApi {
   /// Returns root type for a template path.
   ///
   /// Parameters:
-  /// * [region] - Region code for tenant context
+  /// * [region] - Region code for tenant context. Not-yet-open codes degrade to the universal-only catalog (#759)
   /// * [path] - Account path to check
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
@@ -178,10 +178,10 @@ class BeanAccountStandardsApi {
   }
 
   /// Get account templates
-  /// Returns predefined account templates for a region. Supports filtering by account type and search term.
+  /// Returns predefined account templates for a region. Supports filtering by account type and search term. Not-yet-open region codes return the universal-only catalog (#759).
   ///
   /// Parameters:
-  /// * [region] - Region code (cn, us, de)
+  /// * [region] - Region code (any ISO alpha-2; not-yet-open codes return the universal-only catalog)
   /// * [type] - Filter by account type
   /// * [search] - Search term for path, description, aliases, or localized display name
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation

--- a/lib/api/generated/lib/src/api/onboarding_api.dart
+++ b/lib/api/generated/lib/src/api/onboarding_api.dart
@@ -22,7 +22,7 @@ class OnboardingApi {
   /// 
   ///
   /// Parameters:
-  /// * [region] - Region code for tenant context
+  /// * [region] - Region code for tenant context. Not-yet-open codes are accepted: the universal catalog backs onboarding regardless of region (#759)
   /// * [onboardingDto] 
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request

--- a/lib/api/generated/lib/src/model/region_info_dto.dart
+++ b/lib/api/generated/lib/src/model/region_info_dto.dart
@@ -14,6 +14,7 @@ part 'region_info_dto.g.dart';
 ///
 /// Properties:
 /// * [code] 
+/// * [open] - Whether the region is open (has a ready regional account template). Not-yet-open regions still return identity metadata and degrade to the universal-only catalog.
 /// * [displayName] 
 /// * [parent] 
 /// * [chain] 
@@ -22,6 +23,10 @@ part 'region_info_dto.g.dart';
 abstract class RegionInfoDto implements Built<RegionInfoDto, RegionInfoDtoBuilder> {
   @BuiltValueField(wireName: r'code')
   String get code;
+
+  /// Whether the region is open (has a ready regional account template). Not-yet-open regions still return identity metadata and degrade to the universal-only catalog.
+  @BuiltValueField(wireName: r'open')
+  bool get open;
 
   @BuiltValueField(wireName: r'displayName')
   String get displayName;
@@ -62,6 +67,11 @@ class _$RegionInfoDtoSerializer implements PrimitiveSerializer<RegionInfoDto> {
     yield serializers.serialize(
       object.code,
       specifiedType: const FullType(String),
+    );
+    yield r'open';
+    yield serializers.serialize(
+      object.open,
+      specifiedType: const FullType(bool),
     );
     yield r'displayName';
     yield serializers.serialize(
@@ -114,6 +124,13 @@ class _$RegionInfoDtoSerializer implements PrimitiveSerializer<RegionInfoDto> {
             specifiedType: const FullType(String),
           ) as String;
           result.code = valueDes;
+          break;
+        case r'open':
+          final valueDes = serializers.deserialize(
+            value,
+            specifiedType: const FullType(bool),
+          ) as bool;
+          result.open = valueDes;
           break;
         case r'displayName':
           final valueDes = serializers.deserialize(

--- a/lib/api/generated/lib/src/model/region_info_dto.g.dart
+++ b/lib/api/generated/lib/src/model/region_info_dto.g.dart
@@ -10,6 +10,8 @@ class _$RegionInfoDto extends RegionInfoDto {
   @override
   final String code;
   @override
+  final bool open;
+  @override
   final String displayName;
   @override
   final String? parent;
@@ -23,12 +25,14 @@ class _$RegionInfoDto extends RegionInfoDto {
 
   _$RegionInfoDto._(
       {required this.code,
+      required this.open,
       required this.displayName,
       this.parent,
       required this.chain,
       required this.config})
       : super._() {
     BuiltValueNullFieldError.checkNotNull(code, r'RegionInfoDto', 'code');
+    BuiltValueNullFieldError.checkNotNull(open, r'RegionInfoDto', 'open');
     BuiltValueNullFieldError.checkNotNull(
         displayName, r'RegionInfoDto', 'displayName');
     BuiltValueNullFieldError.checkNotNull(chain, r'RegionInfoDto', 'chain');
@@ -47,6 +51,7 @@ class _$RegionInfoDto extends RegionInfoDto {
     if (identical(other, this)) return true;
     return other is RegionInfoDto &&
         code == other.code &&
+        open == other.open &&
         displayName == other.displayName &&
         parent == other.parent &&
         chain == other.chain &&
@@ -57,6 +62,7 @@ class _$RegionInfoDto extends RegionInfoDto {
   int get hashCode {
     var _$hash = 0;
     _$hash = $jc(_$hash, code.hashCode);
+    _$hash = $jc(_$hash, open.hashCode);
     _$hash = $jc(_$hash, displayName.hashCode);
     _$hash = $jc(_$hash, parent.hashCode);
     _$hash = $jc(_$hash, chain.hashCode);
@@ -69,6 +75,7 @@ class _$RegionInfoDto extends RegionInfoDto {
   String toString() {
     return (newBuiltValueToStringHelper(r'RegionInfoDto')
           ..add('code', code)
+          ..add('open', open)
           ..add('displayName', displayName)
           ..add('parent', parent)
           ..add('chain', chain)
@@ -84,6 +91,10 @@ class RegionInfoDtoBuilder
   String? _code;
   String? get code => _$this._code;
   set code(String? code) => _$this._code = code;
+
+  bool? _open;
+  bool? get open => _$this._open;
+  set open(bool? open) => _$this._open = open;
 
   String? _displayName;
   String? get displayName => _$this._displayName;
@@ -110,6 +121,7 @@ class RegionInfoDtoBuilder
     final $v = _$v;
     if ($v != null) {
       _code = $v.code;
+      _open = $v.open;
       _displayName = $v.displayName;
       _parent = $v.parent;
       _chain = $v.chain.toBuilder();
@@ -140,6 +152,8 @@ class RegionInfoDtoBuilder
           new _$RegionInfoDto._(
               code: BuiltValueNullFieldError.checkNotNull(
                   code, r'RegionInfoDto', 'code'),
+              open: BuiltValueNullFieldError.checkNotNull(
+                  open, r'RegionInfoDto', 'open'),
               displayName: BuiltValueNullFieldError.checkNotNull(
                   displayName, r'RegionInfoDto', 'displayName'),
               parent: parent,


### PR DESCRIPTION
Auto-regenerated Dart API types from OpenAPI spec.

**Trigger:** ign@7a6a447db7b9740f6ba163e811044d33b57990cf