### PR TITLE
chore: sync OpenAPI spec from ign@e85e9088850c3376637b41042c5d12a85f0fa5a0

### DIFF
--- a/lib/api/spec/openapi.yaml
+++ b/lib/api/spec/openapi.yaml
@@ -10007,7 +10007,7 @@ components:
           pattern: ^[a-z]{2,8}-[A-Z]{2}$
           description: >-
             Region-qualified BCP-47 tag whose region subtag equals the region's
-            own ISO 3166-1 code (e.g., ja-JP, zh-CN, en-HK)
+            own ISO 3166-1 code (e.g., ja-JP, zh-CN, zh-HK)
       required:
         - currency
         - dateFormat


### PR DESCRIPTION
Auto-synced OpenAPI spec from ign repository.

**Source:** fire-zu/firela-vlt@e85e9088850c3376637b41042c5d12a85f0fa5a0