### PR TITLE
chore: regenerate Dart API types from OpenAPI spec

### DIFF
--- a/lib/api/generated/lib/src/api/bean_category_catalog_api.dart
+++ b/lib/api/generated/lib/src/api/bean_category_catalog_api.dart
@@ -19,7 +19,7 @@ class BeanCategoryCatalogApi {
   const BeanCategoryCatalogApi(this._dio, this._serializers);
 
   /// List category catalog for a region
-  /// Returns the region-scoped category slugs (expense/income/investment/banking/transfer/payment) for the NLP result picker. CN-exclusive payment instruments (huabei/baitiao) appear only under /cn.
+  /// Returns the region-scoped category slugs (expense/income/investment/banking/transfer/payment) for the NLP result picker, each with the categoryAccount paths the region-enabled system rules map it to (#816). CN-exclusive payment instruments (huabei/baitiao) appear only under /cn.
   ///
   /// Parameters:
   /// * [region] - Region code for tenant context

--- a/lib/api/generated/lib/src/model/category_catalog_entry_dto.dart
+++ b/lib/api/generated/lib/src/model/category_catalog_entry_dto.dart
@@ -16,6 +16,7 @@ part 'category_catalog_entry_dto.g.dart';
 /// * [scenario] - Display scenario group (maps to frontend picker _scenario)
 /// * [icon] - Lucide icon name
 /// * [regions] - Applicable regions ('*' = all, 'cn' = CN-only)
+/// * [categoryAccounts] - Beancount account paths (categoryAccount) of the region-enabled system rules whose categoryKeywords include this slug (#816). System rules only (public endpoint — user rules excluded); one-to-many by design (e.g. 'utilities' → Electricity/Water/Internet/Gas), sorted, [] when no rule maps the slug.
 @BuiltValue()
 abstract class CategoryCatalogEntryDto implements Built<CategoryCatalogEntryDto, CategoryCatalogEntryDtoBuilder> {
   /// Category slug (single source-of-truth)
@@ -34,6 +35,10 @@ abstract class CategoryCatalogEntryDto implements Built<CategoryCatalogEntryDto,
   /// Applicable regions ('*' = all, 'cn' = CN-only)
   @BuiltValueField(wireName: r'regions')
   BuiltList<String> get regions;
+
+  /// Beancount account paths (categoryAccount) of the region-enabled system rules whose categoryKeywords include this slug (#816). System rules only (public endpoint — user rules excluded); one-to-many by design (e.g. 'utilities' → Electricity/Water/Internet/Gas), sorted, [] when no rule maps the slug.
+  @BuiltValueField(wireName: r'categoryAccounts')
+  BuiltList<String> get categoryAccounts;
 
   CategoryCatalogEntryDto._();
 
@@ -76,6 +81,11 @@ class _$CategoryCatalogEntryDtoSerializer implements PrimitiveSerializer<Categor
     yield r'regions';
     yield serializers.serialize(
       object.regions,
+      specifiedType: const FullType(BuiltList, [FullType(String)]),
+    );
+    yield r'categoryAccounts';
+    yield serializers.serialize(
+      object.categoryAccounts,
       specifiedType: const FullType(BuiltList, [FullType(String)]),
     );
   }
@@ -128,6 +138,13 @@ class _$CategoryCatalogEntryDtoSerializer implements PrimitiveSerializer<Categor
             specifiedType: const FullType(BuiltList, [FullType(String)]),
           ) as BuiltList<String>;
           result.regions.replace(valueDes);
+          break;
+        case r'categoryAccounts':
+          final valueDes = serializers.deserialize(
+            value,
+            specifiedType: const FullType(BuiltList, [FullType(String)]),
+          ) as BuiltList<String>;
+          result.categoryAccounts.replace(valueDes);
           break;
         default:
           unhandled.add(key);

--- a/lib/api/generated/lib/src/model/category_catalog_entry_dto.g.dart
+++ b/lib/api/generated/lib/src/model/category_catalog_entry_dto.g.dart
@@ -109,6 +109,8 @@ class _$CategoryCatalogEntryDto extends CategoryCatalogEntryDto {
   final String icon;
   @override
   final BuiltList<String> regions;
+  @override
+  final BuiltList<String> categoryAccounts;
 
   factory _$CategoryCatalogEntryDto(
           [void Function(CategoryCatalogEntryDtoBuilder)? updates]) =>
@@ -118,7 +120,8 @@ class _$CategoryCatalogEntryDto extends CategoryCatalogEntryDto {
       {required this.slug,
       required this.scenario,
       required this.icon,
-      required this.regions})
+      required this.regions,
+      required this.categoryAccounts})
       : super._() {
     BuiltValueNullFieldError.checkNotNull(
         slug, r'CategoryCatalogEntryDto', 'slug');
@@ -128,6 +131,8 @@ class _$CategoryCatalogEntryDto extends CategoryCatalogEntryDto {
         icon, r'CategoryCatalogEntryDto', 'icon');
     BuiltValueNullFieldError.checkNotNull(
         regions, r'CategoryCatalogEntryDto', 'regions');
+    BuiltValueNullFieldError.checkNotNull(
+        categoryAccounts, r'CategoryCatalogEntryDto', 'categoryAccounts');
   }
 
   @override
@@ -146,7 +151,8 @@ class _$CategoryCatalogEntryDto extends CategoryCatalogEntryDto {
         slug == other.slug &&
         scenario == other.scenario &&
         icon == other.icon &&
-        regions == other.regions;
+        regions == other.regions &&
+        categoryAccounts == other.categoryAccounts;
   }
 
   @override
@@ -156,6 +162,7 @@ class _$CategoryCatalogEntryDto extends CategoryCatalogEntryDto {
     _$hash = $jc(_$hash, scenario.hashCode);
     _$hash = $jc(_$hash, icon.hashCode);
     _$hash = $jc(_$hash, regions.hashCode);
+    _$hash = $jc(_$hash, categoryAccounts.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
@@ -166,7 +173,8 @@ class _$CategoryCatalogEntryDto extends CategoryCatalogEntryDto {
           ..add('slug', slug)
           ..add('scenario', scenario)
           ..add('icon', icon)
-          ..add('regions', regions))
+          ..add('regions', regions)
+          ..add('categoryAccounts', categoryAccounts))
         .toString();
   }
 }
@@ -194,6 +202,12 @@ class CategoryCatalogEntryDtoBuilder
       _$this._regions ??= new ListBuilder<String>();
   set regions(ListBuilder<String>? regions) => _$this._regions = regions;
 
+  ListBuilder<String>? _categoryAccounts;
+  ListBuilder<String> get categoryAccounts =>
+      _$this._categoryAccounts ??= new ListBuilder<String>();
+  set categoryAccounts(ListBuilder<String>? categoryAccounts) =>
+      _$this._categoryAccounts = categoryAccounts;
+
   CategoryCatalogEntryDtoBuilder() {
     CategoryCatalogEntryDto._defaults(this);
   }
@@ -205,6 +219,7 @@ class CategoryCatalogEntryDtoBuilder
       _scenario = $v.scenario;
       _icon = $v.icon;
       _regions = $v.regions.toBuilder();
+      _categoryAccounts = $v.categoryAccounts.toBuilder();
       _$v = null;
     }
     return this;
@@ -235,12 +250,15 @@ class CategoryCatalogEntryDtoBuilder
                   scenario, r'CategoryCatalogEntryDto', 'scenario'),
               icon: BuiltValueNullFieldError.checkNotNull(
                   icon, r'CategoryCatalogEntryDto', 'icon'),
-              regions: regions.build());
+              regions: regions.build(),
+              categoryAccounts: categoryAccounts.build());
     } catch (_) {
       late String _$failedField;
       try {
         _$failedField = 'regions';
         regions.build();
+        _$failedField = 'categoryAccounts';
+        categoryAccounts.build();
       } catch (e) {
         throw new BuiltValueNestedFieldError(
             r'CategoryCatalogEntryDto', _$failedField, e.toString());

--- a/lib/api/generated/lib/src/model/client_parsed_data_dto.dart
+++ b/lib/api/generated/lib/src/model/client_parsed_data_dto.dart
@@ -17,7 +17,7 @@ part 'client_parsed_data_dto.g.dart';
 /// * [date] - Transaction date (ISO 8601)
 /// * [payee] - Payee/merchant name
 /// * [narration] - Transaction narration
-/// * [category] - Category slug
+/// * [category] - Category in canonical form (catalog slug or Stage-2 rule keyword token, ADR-0116) — echo back verbatim from parsedData.category. Foreign forms (locale display names, account paths) are rejected with nlp.category.invalid.
 /// * [incomeType] - Income type
 /// * [incomeSource] - Income source
 /// * [symbol] - Security symbol code (e.g., 600519, AAPL)
@@ -49,7 +49,7 @@ abstract class ClientParsedDataDto implements Built<ClientParsedDataDto, ClientP
   @BuiltValueField(wireName: r'narration')
   String? get narration;
 
-  /// Category slug
+  /// Category in canonical form (catalog slug or Stage-2 rule keyword token, ADR-0116) — echo back verbatim from parsedData.category. Foreign forms (locale display names, account paths) are rejected with nlp.category.invalid.
   @BuiltValueField(wireName: r'category')
   String? get category;
 

--- a/lib/api/generated/lib/src/model/nlp_parsed_data_dto.dart
+++ b/lib/api/generated/lib/src/model/nlp_parsed_data_dto.dart
@@ -17,7 +17,7 @@ part 'nlp_parsed_data_dto.g.dart';
 /// * [date] - Transaction date (ISO format)
 /// * [payee] - Payee name
 /// * [narration] - Transaction narration
-/// * [category] - Category
+/// * [category] - Category in canonical form: a CATEGORY_CATALOG slug (GET /{region}/bean/categories) or a Stage-2 rule categoryKeywords token (ADR-0116 D2). Never a locale display name or a beancount account path. Echo back verbatim on confirm.
 /// * [incomeType] - Income type (e.g., Salary, Bonus, Dividend, Interest)
 /// * [incomeSource] - Income source (e.g., company name)
 /// * [symbol] - Security symbol code (e.g., 600519, AAPL)
@@ -49,7 +49,7 @@ abstract class NlpParsedDataDto implements Built<NlpParsedDataDto, NlpParsedData
   @BuiltValueField(wireName: r'narration')
   String? get narration;
 
-  /// Category
+  /// Category in canonical form: a CATEGORY_CATALOG slug (GET /{region}/bean/categories) or a Stage-2 rule categoryKeywords token (ADR-0116 D2). Never a locale display name or a beancount account path. Echo back verbatim on confirm.
   @BuiltValueField(wireName: r'category')
   String? get category;
 

--- a/lib/api/generated/lib/src/serializers.g.dart
+++ b/lib/api/generated/lib/src/serializers.g.dart
@@ -704,6 +704,9 @@ Serializers _$serializers = (new Serializers().toBuilder()
           const FullType(BuiltList, const [const FullType(String)]),
           () => new ListBuilder<String>())
       ..addBuilderFactory(
+          const FullType(BuiltList, const [const FullType(String)]),
+          () => new ListBuilder<String>())
+      ..addBuilderFactory(
           const FullType(BuiltList, const [const FullType(CreatePostingDto)]),
           () => new ListBuilder<CreatePostingDto>())
       ..addBuilderFactory(


### PR DESCRIPTION
Auto-regenerated Dart API types from OpenAPI spec.

**Trigger:** ign@cf74deb9cfd937c246efd63f3eb03470a92f5370