### PR TITLE
chore: regenerate Dart API types from OpenAPI spec

### DIFF
--- a/lib/api/generated/lib/src/api/bean_accounts_api.dart
+++ b/lib/api/generated/lib/src/api/bean_accounts_api.dart
@@ -377,7 +377,7 @@ class BeanAccountsApi {
   /// * [type] - Filter by account type
   /// * [status] - Filter by status
   /// * [isCustom] - Filter by custom (user-created) accounts only
-  /// * [search] - Search term for account path
+  /// * [search] - Search term matched against account path and user-set display name (case-insensitive)
   /// * [limit] - Maximum number of results
   /// * [offset] - Number of results to skip
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation


### PR DESCRIPTION
Auto-regenerated Dart API types from OpenAPI spec.

**Trigger:** ign@2aa4e6b322bfa71c5dbbd2e2233bd15caa3cd55c